### PR TITLE
Permission "tabs" is needed for proper work

### DIFF
--- a/send-to-ifttt/manifest.json
+++ b/send-to-ifttt/manifest.json
@@ -19,7 +19,8 @@
   },
   "permissions": [
     "https://maker.ifttt.com/",
-    "storage"
+    "storage",
+    "tabs"
   ],
   "options_page": "options.html"
 }


### PR DESCRIPTION
To get chrome.tabs.Tab.url and chrome.tabs.Tab.title properties, you need "tabs" permission
Those properties are used there, so extension doesn't work (doesn't send url and title to IFTTT) without that permission:
https://github.com/drxzcl/chrome-send-to-ifttt/blob/master/send-to-ifttt/background.js#L17-L18

Check documentation for more information:
https://developer.chrome.com/extensions/tabs#type-Tab